### PR TITLE
fix(security): bump picomatch >=4.0.4 — fix ReDoS via extglob quantifiers [HIGH]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,9 +3006,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
+  "overrides": {
+    "picomatch": ">=4.0.4"
+  },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@tailwindcss/postcss": "^4.0.14",


### PR DESCRIPTION
## Security Fix: picomatch ReDoS (HIGH)

### Scanner & Findings

| Finding ID | Source | Severity | Advisory |
|---|---|---|---|
| 3ee9511fabfb53d0 | npm-audit | HIGH | [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj) |

### Vulnerability Fixed

- **GHSA-c2c7-rcm5-vvqj**: picomatch >=4.0.0 <4.0.4 — ReDoS vulnerability via extglob quantifiers. An attacker able to supply crafted glob patterns could cause catastrophic backtracking in the regex engine.

### What Changed

`picomatch` is a transitive dependency (used by vite's file watcher and other dev tooling). The installed version was `4.0.3`, which falls in the vulnerable range `>=4.0.0 <4.0.4`.

Added an `overrides` entry in `package.json` to force all nested picomatch installs to resolve at `>=4.0.4`. Ran `npm install` to regenerate `package-lock.json`; picomatch was updated to `4.0.4`.

### Why This Approach

picomatch is not a direct dependency — using `overrides` is the standard npm mechanism for pinning transitive dependencies to a safe version.

### Manual Verification Steps

1. Check out this branch and run `npm ci`.
2. Confirm `npm ls picomatch` shows only version >= 4.0.4.
3. Run `npm audit` — the picomatch advisory GHSA-c2c7-rcm5-vvqj should no longer appear.
4. Run `npm run build` to confirm the build still succeeds.

### Scan Run Reference

Scan date: 2026-04-28, commit 8f4e82e. Full summary: VULN-2 scan artifacts.