### PR TITLE
fix(security): upgrade vite to ^6.4.2 — fix Arbitrary File Read via WebSocket [HIGH]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-icons": "^5.5.0",
         "react-intersection-observer": "^9.16.0",
         "tailwindcss": "^4.0.14",
-        "vite": "^6.2.0"
+        "vite": "^6.4.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3351,9 +3351,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^9.16.0",
     "tailwindcss": "^4.0.14",
-    "vite": "^6.2.0"
+    "vite": "^6.4.2"
   }
 }


### PR DESCRIPTION
## Security Fix: Vite Arbitrary File Read via WebSocket (HIGH)

### Scanner & Findings

| Finding ID | Source | Severity | Advisory |
|---|---|---|---|
| c003596a52017408 | npm-audit | HIGH | [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583) |

### Vulnerability Fixed

- **GHSA-p9ff-h696-f583**: vite >=6.0.0 <=6.4.1 — Vite Dev Server WebSocket vulnerability allows arbitrary file read. An attacker with network access to the dev server could read files outside the project root through a crafted WebSocket message.

### What Changed

`vite` is a direct devDependency. The installed version was `6.4.1`, which is in the vulnerable range `>=6.0.0 <=6.4.1`.

Updated the `vite` version specifier in `package.json` from `^6.2.0` to `^6.4.2`, then ran `npm install`. The lockfile now resolves vite at `6.4.2`.

```diff
-    "vite": "^6.2.0"
+    "vite": "^6.4.2"
```

### Why This Is Safe

vite uses semantic versioning. Moving from 6.4.1 to 6.4.2 is a patch release — no breaking changes. The project's existing build configuration and plugins remain compatible.

### Manual Verification Steps

1. Check out this branch and run `npm ci`.
2. Confirm `npm ls vite` shows version 6.4.2.
3. Run `npm audit` — the vite advisory GHSA-p9ff-h696-f583 should no longer appear.
4. Run `npm run build` to confirm the build still succeeds.
5. (Optional) Run `npm run dev` and verify the dev server starts correctly.

### Scan Run Reference

Scan date: 2026-04-28, commit 8f4e82e. Full summary: VULN-2 scan artifacts.