### PR TITLE
fix(security): bundle medium fixes — ajv/brace-expansion/postcss/picomatch upgrades + SRI integrity [MEDIUM bundle]

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Austin Arlint | DevSecOps Engineer</title>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js" integrity="sha384-d+UOwmNNIC7V4izkTAKSXzWhjC2GxiS9PTykO1XdOPC3nc2z65UOS7SP6QdKPA70" crossorigin="anonymous"></script>
   </head>
   <body>
     <div id="particles-js"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "framer-motion": "^12.5.0",
         "globals": "^15.15.0",
-        "postcss": "^8.5.3",
+        "postcss": "^8.5.10",
         "react-icons": "^5.5.0",
         "react-intersection-observer": "^9.16.0",
         "tailwindcss": "^4.0.14",
@@ -1666,16 +1666,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1744,21 +1744,26 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1859,13 +1864,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2202,19 +2200,29 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2513,9 +2521,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -2873,9 +2881,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.10.tgz",
-      "integrity": "sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -3019,9 +3027,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -3039,7 +3047,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3062,16 +3070,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -3125,6 +3123,16 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3338,16 +3346,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
+  "overrides": {
+    "ajv": ">=6.14.0",
+    "brace-expansion": ">=1.1.13"
+  },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@tailwindcss/postcss": "^4.0.14",
@@ -25,7 +29,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "framer-motion": "^12.5.0",
     "globals": "^15.15.0",
-    "postcss": "^8.5.3",
+    "postcss": "^8.5.10",
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^9.16.0",
     "tailwindcss": "^4.0.14",


### PR DESCRIPTION
## Security Fix Bundle: Medium Findings

This PR bundles all medium-severity security fixes that don't warrant individual PRs.

---

### Findings Addressed in This PR

| Finding ID | Source | Severity | Package/Issue | Advisory |
|---|---|---|---|---|
| 18a58de6aa992ce2 | npm-audit | MEDIUM | ajv <6.14.0 | [GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6) |
| df7b59f5c5b72203 | npm-audit | MEDIUM | brace-expansion <1.1.13 | [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) |
| 7576b3dc0736ff60 | npm-audit | MEDIUM | postcss <8.5.10 | [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) |
| 56603ce6f5bac0ef | semgrep | MEDIUM | Missing SRI on particles.js CDN script | — |

### Medium Findings Addressed by Separate HIGH PRs (not duplicated here)

| Finding ID | Covered by |
|---|---|
| 455e3acba574af83 (picomatch Method Injection) | PR #4 (picomatch upgrade) |
| ee0dd7a9775f1106 (vite Path Traversal .map) | PR #6 (vite upgrade) |

### Medium Findings Skipped (require `workflow` scope token)

| Finding ID | Issue | Reason Skipped |
|---|---|---|
| 4acd04474b9f5429 | Unpinned actions/checkout@v4 (build:26) | GITHUB_TOKEN lacks `workflow` scope |
| 02a581806d80a5b1 | Unpinned actions/setup-node@v4 (build:28) | GITHUB_TOKEN lacks `workflow` scope |
| d3570977b2889503 | Unpinned actions/upload-artifact@v4 (build:36) | GITHUB_TOKEN lacks `workflow` scope |
| f9881c62784a689c | Unpinned actions/checkout@v4 (deploy:44) | GITHUB_TOKEN lacks `workflow` scope |
| 9122f2a124718267 | Unpinned actions/download-artifact@v4 (deploy:47) | GITHUB_TOKEN lacks `workflow` scope |
| ee158250b51dcbd5 | Unpinned actions/configure-pages@v4 (deploy:52) | GITHUB_TOKEN lacks `workflow` scope |
| eae1c145bc37daf0 | Unpinned actions/upload-pages-artifact@v3 (deploy:54) | GITHUB_TOKEN lacks `workflow` scope |
| 2776195cf71dac94 | Unpinned actions/deploy-pages@v4 (deploy:58) | GITHUB_TOKEN lacks `workflow` scope |

**Manual fix for CI action pinning** — replace the tag references in `.github/workflows/build.yaml` with these commit SHAs:
```
actions/checkout@v4          → actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
actions/setup-node@v4        → actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
actions/upload-artifact@v4   → actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
actions/download-artifact@v4 → actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
actions/configure-pages@v4   → actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d
actions/upload-pages-artifact@v3 → actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
actions/deploy-pages@v4      → actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
```

---

### What Changed

**Commit 1 — npm package upgrades:**
- Added `overrides` in `package.json` to force `ajv >= 6.14.0` (resolved to 8.20.0) and `brace-expansion >= 1.1.13` (resolved to 5.0.5)
- Bumped direct devDependency `postcss` from `^8.5.3` to `^8.5.10` (resolved to 8.5.12) to fix XSS via unescaped `</style>` in CSS stringify output

**Commit 2 — SRI integrity attribute:**
- Added `integrity="sha384-d+UOwmNNIC7V4izkTAKSXzWhjC2GxiS9PTykO1XdOPC3nc2z65UOS7SP6QdKPA70"` and `crossorigin="anonymous"` to the particles.js CDN script tag in `index.html` (line 10). Hash was computed from the live CDN file: `curl -s URL | openssl dgst -sha384 -binary | openssl base64 -A`

### Manual Verification Steps

1. Check out this branch and run `npm ci`.
2. Run `npm audit` — ajv, brace-expansion, and postcss advisories should no longer appear.
3. Run `npm run build` to confirm the build still succeeds.
4. Open the built site in a browser; verify the particles.js animation still works (browser validates SRI and loads the script).
5. Apply the CI action SHA pinning above in a separate PR with `workflow`-scoped token.

### Scan Run Reference

Scan date: 2026-04-28, commit 8f4e82e. Full summary: VULN-2 scan artifacts.